### PR TITLE
Fixed errors/warnings when using latest toolchains + Additional fixes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -124,7 +124,7 @@ CINCS =
 CFLAGS = -g$(DEBUG)
 CFLAGS += $(CDEFS) $(CINCS)
 CFLAGS += -O$(OPT)
-CFLAGS += -funsigned-char -funsigned-bitfields -fpack-struct -fshort-enums -mno-tablejump
+CFLAGS += -funsigned-char -funsigned-bitfields -fpack-struct -fshort-enums -fno-jump-tables
 CFLAGS += -Wall -Wstrict-prototypes
 CFLAGS += -Wa,-adhlns=$(<:.c=.lst)
 CFLAGS += $(patsubst %,-I%,$(EXTRAINCDIRS))
@@ -209,10 +209,10 @@ LDFLAGS += -Wl,--section-start=.text=$(BOOTLOADER_ADDRESS)
 # Type: avrdude -c ?
 # to get a full listing.
 #
-AVRDUDE_PROGRAMMER = stk500v2
+AVRDUDE_PROGRAMMER = arduino_as_isp
 
 # com1 = serial port. Use lpt1 to connect to parallel port.
-AVRDUDE_PORT = com1    # programmer connected to serial device
+AVRDUDE_PORT = com4    # programmer connected to serial device
 
 AVRDUDE_WRITE_FLASH = -U flash:w:$(TARGET).hex
 #AVRDUDE_WRITE_EEPROM = -U eeprom:w:$(TARGET).eep
@@ -232,10 +232,14 @@ AVRDUDE_WRITE_FLASH = -U flash:w:$(TARGET).hex
 # to submit bug reports.
 #AVRDUDE_VERBOSE = -v -v
 
+# Uncomment the following line if you need to override the Baudrate
+#AVRDUDE_BAUDRATE = -b 19000
+
 AVRDUDE_FLAGS = -p $(MCU) -P $(AVRDUDE_PORT) -c $(AVRDUDE_PROGRAMMER)
 AVRDUDE_FLAGS += $(AVRDUDE_NO_VERIFY)
 AVRDUDE_FLAGS += $(AVRDUDE_VERBOSE)
 AVRDUDE_FLAGS += $(AVRDUDE_ERASE_COUNTER)
+AVRDUDE_FLAGS += $(AVRDUDE_BAUDRATE)
 
 
 
@@ -270,13 +274,16 @@ DEBUG_HOST = localhost
 
 #============================================================================
 
+# Define here the location of the AVR-GCC and AVRDUDE executables
+CC_PREFIX ?= /cygdrive/b/avr-gcc-14.1.0-x64-windows/bin/avr
+AVRDUDE_FOLDER ?= /cygdrive/b/avr-gcc-14.1.0-x64-windows/bin
 
 # Define programs and commands.
-CC = /Applications/Arduino.app/Contents/Resources/Java/hardware/tools/avr/bin/avr-gcc
-OBJCOPY = /Applications/Arduino.app/Contents/Resources/Java/hardware/tools/avr/bin/avr-objcopy
-OBJDUMP = /Applications/Arduino.app/Contents/Resources/Java/hardware/tools/avr/bin/avr-objdump
-SIZE = /Applications/Arduino.app/Contents/Resources/Java/hardware/tools/avr/bin/avr-size
-NM = /Applications/Arduino.app/Contents/Resources/Java/hardware/tools/avr/bin/avr-nm
+CC = $(CC_PREFIX)-gcc
+OBJCOPY = $(CC_PREFIX)-objcopy
+OBJDUMP = $(CC_PREFIX)-objdump
+SIZE = $(CC_PREFIX)-size
+NM = $(CC_PREFIX)-nm
 
 # SHELL = sh
 # CC = avr-gcc
@@ -284,7 +291,7 @@ NM = /Applications/Arduino.app/Contents/Resources/Java/hardware/tools/avr/bin/av
 # OBJDUMP = avr-objdump
 # SIZE = avr-size
 # NM = avr-nm
-AVRDUDE = avrdude
+AVRDUDE = $(AVRDUDE_FOLDER)/avrdude
 REMOVE = rm -f
 COPY = cp
 WINSHELL = cmd
@@ -439,7 +446,7 @@ end:
 
 # Display size of file.
 HEXSIZE = $(SIZE) --target=$(FORMAT) $(TARGET).hex
-ELFSIZE = $(SIZE) --format=avr --mcu=$(MCU) $(TARGET).elf
+ELFSIZE = $(SIZE) $(TARGET).elf
 
 sizebefore:
 	@if test -f $(TARGET).elf; then echo; echo $(MSG_SIZE_BEFORE); $(ELFSIZE); \

--- a/Makefile
+++ b/Makefile
@@ -213,7 +213,7 @@ LDFLAGS += -Wl,--section-start=.bootloader_trampoline=$(BOOTLOADER_TRAMPOLINE)
 AVRDUDE_PROGRAMMER = arduino_as_isp
 
 # com1 = serial port. Use lpt1 to connect to parallel port.
-AVRDUDE_PORT = com4    # programmer connected to serial device
+AVRDUDE_PORT ?= com4    # programmer connected to serial device
 
 AVRDUDE_WRITE_FLASH = -U flash:w:$(TARGET).hex
 #AVRDUDE_WRITE_EEPROM = -U eeprom:w:$(TARGET).eep
@@ -234,7 +234,7 @@ AVRDUDE_WRITE_FLASH = -U flash:w:$(TARGET).hex
 #AVRDUDE_VERBOSE = -v -v
 
 # Uncomment the following line if you need to override the Baudrate
-#AVRDUDE_BAUDRATE = -b 19000
+#AVRDUDE_BAUDRATE = -b 19200
 
 AVRDUDE_FLAGS = -p $(MCU) -P $(AVRDUDE_PORT) -c $(AVRDUDE_PROGRAMMER)
 AVRDUDE_FLAGS += $(AVRDUDE_NO_VERIFY)
@@ -358,7 +358,7 @@ mega2560:	BOOTLOADER_ADDRESS = 3E000
 mega2560:	BOOTLOADER_TRAMPOLINE = 3FFF0
 mega2560:	CFLAGS += -D_MEGA_BOARD_
 mega2560:	begin gccversion sizebefore build sizeafter end 
-			mv $(TARGET).hex stk500boot_v2_mega2560.hex
+			#mv $(TARGET).hex $(TARGETFINAL).hex
 
 ############################################################
 #	Jul 6,	2010	<MLS> Adding 2560 support

--- a/Makefile
+++ b/Makefile
@@ -200,6 +200,7 @@ LDFLAGS += $(PRINTF_LIB) $(SCANF_LIB) $(MATH_LIB)
 #LDFLAGS += -Wl,--section-start=.text=$(BOOTLOADER_ADDRESS) -nostartfiles -nodefaultlibs
 #LDFLAGS += -Wl,--section-start=.text=$(BOOTLOADER_ADDRESS) -nostartfiles
 LDFLAGS += -Wl,--section-start=.text=$(BOOTLOADER_ADDRESS)
+LDFLAGS += -Wl,--section-start=.bootloader_trampoline=$(BOOTLOADER_TRAMPOLINE)
 
 #---------------- Programming Options (avrdude) ----------------
 
@@ -239,7 +240,9 @@ AVRDUDE_FLAGS = -p $(MCU) -P $(AVRDUDE_PORT) -c $(AVRDUDE_PROGRAMMER)
 AVRDUDE_FLAGS += $(AVRDUDE_NO_VERIFY)
 AVRDUDE_FLAGS += $(AVRDUDE_VERBOSE)
 AVRDUDE_FLAGS += $(AVRDUDE_ERASE_COUNTER)
-AVRDUDE_FLAGS += $(AVRDUDE_BAUDRATE)
+ifdef AVRDUDE_BAUDRATE
+AVRDUDE_FLAGS += -b $(AVRDUDE_BAUDRATE)
+endif
 
 
 
@@ -341,6 +344,7 @@ ALL_ASFLAGS = -mmcu=$(MCU) -I. -x assembler-with-cpp $(ASFLAGS)
 mega1280: MCU = atmega1280
 mega1280: F_CPU = 16000000
 mega1280: BOOTLOADER_ADDRESS = 1E000
+mega1280: BOOTLOADER_TRAMPOLINE = 1FFF0
 mega1280: CFLAGS += -D_MEGA_BOARD_
 mega1280: begin gccversion sizebefore build sizeafter end 
 			mv $(TARGET).hex stk500boot_v2_mega1280.hex
@@ -351,6 +355,7 @@ mega1280: begin gccversion sizebefore build sizeafter end
 mega2560:	MCU = atmega2560
 mega2560:	F_CPU = 16000000
 mega2560:	BOOTLOADER_ADDRESS = 3E000
+mega2560:	BOOTLOADER_TRAMPOLINE = 3FFF0
 mega2560:	CFLAGS += -D_MEGA_BOARD_
 mega2560:	begin gccversion sizebefore build sizeafter end 
 			mv $(TARGET).hex stk500boot_v2_mega2560.hex
@@ -360,6 +365,7 @@ mega2560:	begin gccversion sizebefore build sizeafter end
 mighty2560:	MCU = atmega2560
 mighty2560:	F_CPU = 16000000
 mighty2560:	BOOTLOADER_ADDRESS = 3E000
+mighty2560:	BOOTLOADER_TRAMPOLINE = 3FFF0
 mighty2560:	CFLAGS += -D_MEGA_BOARD_ 
 mighty2560:	CFLAGS += -fno-inline-small-functions
 mighty2560:	CFLAGS += -DBAUDRATE=57600 -DUART_BAUDRATE_DOUBLE_SPEED=0
@@ -378,6 +384,7 @@ amber128: MCU = atmega128
 #amber128: F_CPU = 16000000
 amber128: F_CPU = 14745600
 amber128: BOOTLOADER_ADDRESS = 1E000
+amber128: BOOTLOADER_TRAMPOLINE = 1FFF0
 amber128: CFLAGS += -D_BOARD_AMBER128_
 amber128: begin gccversion sizebefore build sizeafter end 
 			mv $(TARGET).hex stk500boot_v2_amber128.hex
@@ -387,6 +394,7 @@ amber128: begin gccversion sizebefore build sizeafter end
 m2561: MCU = atmega2561
 m2561: F_CPU = 8000000
 m2561: BOOTLOADER_ADDRESS = 3E000
+m2561: BOOTLOADER_TRAMPOLINE = 3FFF0
 m2561: CFLAGS += -D_ANDROID_2561_ -DBAUDRATE=57600
 m2561: begin gccversion sizebefore build sizeafter end 
 			mv $(TARGET).hex stk500boot_v2_android2561.hex
@@ -403,6 +411,7 @@ m2561: begin gccversion sizebefore build sizeafter end
 cerebot:	MCU = atmega2560
 cerebot:	F_CPU = 8000000
 cerebot:	BOOTLOADER_ADDRESS = 3E000
+cerebot:	BOOTLOADER_TRAMPOLINE = 3FFF0
 cerebot:	CFLAGS += -D_CEREBOTPLUS_BOARD_ -DBAUDRATE=38400 -DUART_BAUDRATE_DOUBLE_SPEED=1
 cerebot:	begin gccversion sizebefore build sizeafter end 
 			mv $(TARGET).hex stk500boot_v2_cerebotplus.hex
@@ -413,6 +422,7 @@ cerebot:	begin gccversion sizebefore build sizeafter end
 penguino: MCU = atmega32
 penguino: F_CPU = 16000000
 penguino: BOOTLOADER_ADDRESS = 7800
+penguino: BOOTLOADER_TRAMPOLINE = 7FF0
 penguino: CFLAGS += -D_PENGUINO_ -DBAUDRATE=57600
 penguino: begin gccversion sizebefore build sizeafter end 
 			mv $(TARGET).hex stk500boot_v2_penguino.hex

--- a/stk500boot.c
+++ b/stk500boot.c
@@ -535,6 +535,7 @@ uint32_t count = 0;
 void (*app_start)(void) = 0x0000;
 
 
+
 int __attribute__ ((noinline)) bootloader_program_page(address_t address, unsigned char *p, unsigned int	size) {
     unsigned int	data;
     unsigned char	highByte, lowByte;
@@ -564,6 +565,15 @@ int __attribute__ ((noinline)) bootloader_program_page(address_t address, unsign
     
     return 0;    
 }
+
+void __attribute__((naked,section(".bootloader_trampoline"))) bootloader_trampoline(void);
+
+void bootloader_trampoline(void) {
+     __asm__ __volatile__ ("%~jmp " __STRINGIFY(bootloader_program_page) ::); 
+}
+
+
+
 
 
 //*****************************************************************************


### PR DESCRIPTION
- Fixed errors/warnings when using latest toolchains
- Fixed the flash page erasing/programming misalignment happening if the programming was not starting at address 0x0 or skipping programming pages
- Moved the flash page programming into a self contained function (bootloader_program_page) that can be used from Application Space by its address.
- Added trampoline in the end of the flash to allow access to bootloader functions at fixed address

